### PR TITLE
feature: reduce boilerplate necessary to use rules_ai

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -1,4 +1,5 @@
-# Rules to supply what the user hasn't alreayd overridden.
+# Rules to supply what the user hasn't already overridden: if a user wants to override one of the
+# "fallback" definitions below, simply define before the call to "dependencies()"
 #
 # The intent is for a simplification of what the user needs to maintain.
 
@@ -35,3 +36,4 @@ def dependencies():
         strip_prefix = "rules_python-0.25.0",
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.25.0/rules_python-0.25.0.tar.gz",
     )
+

--- a/examples/demo_rules_python/WORKSPACE
+++ b/examples/demo_rules_python/WORKSPACE
@@ -2,9 +2,9 @@
 
 workspace(name = "demo_rules_python")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # if copy-pasting, use this instead:
+#
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # http_archive(
 #     name = "rules_ai",
 #     sha256 = "...",
@@ -20,15 +20,14 @@ load("@rules_ai//:deps.bzl", rules_ai_dependencies = "dependencies")
 
 rules_ai_dependencies()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_ai//:python_defs.bzl", rules_ai_py_toolchain = "py_toolchain")
 
-py_repositories()
+rules_ai_py_toolchain(python_version = "3.9", python_repo_name = "python39")
 
-# Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
+# demo_vendored_requirements shows how to use a pre-curated set of requirements already expanded to
+# a lock file, reducing parse/resolution at the individual repo level.  Keeping the ability to
+# custom-define a pip_parse(), this version is closer to a basic rules_python usage, including a
+# call to pip_parse() before the install_deps() call.
 
 load("@python39//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")

--- a/examples/demo_vendored_requirements/WORKSPACE
+++ b/examples/demo_vendored_requirements/WORKSPACE
@@ -2,9 +2,9 @@
 
 workspace(name = "demo_vendored_requirements")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # if copy-pasting, use this instead:
+#
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # http_archive(
 #     name = "rules_ai",
 #     sha256 = "...",
@@ -20,22 +20,12 @@ load("@rules_ai//:deps.bzl", rules_ai_dependencies = "dependencies")
 
 rules_ai_dependencies()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_ai//:python_defs.bzl", rules_ai_py_toolchain = "py_toolchain")
 
-py_repositories()
+rules_ai_py_toolchain(python_version = "3.9", python_repo_name = "python39")
 
-# Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
-
-#load("@python39//:defs.bzl", "interpreter")
-
-# Because we drop out the pip_parse(), we need to explicitly call one of the magic hidden helper-functions:
-load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
-
-pip_install_dependencies()
+# Load a pre-curated set of default per-OS requirements, naming the repo "pypi", then (a standard
+# step of "rules_python" use) install the dependencies defined in this vendored requirements spec
 
 load("@rules_ai//:requirements.bzl", "vendored_requirements")
 

--- a/examples/huggingface_transformer_distilgpt2/WORKSPACE
+++ b/examples/huggingface_transformer_distilgpt2/WORKSPACE
@@ -2,9 +2,9 @@
 
 workspace(name = "huggingface_transformer_distilgpt2")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # if copy-pasting, use this instead:
+#
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # http_archive(
 #     name = "rules_ai",
 #     sha256 = "...",
@@ -20,22 +20,12 @@ load("@rules_ai//:deps.bzl", rules_ai_dependencies = "dependencies")
 
 rules_ai_dependencies()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_ai//:python_defs.bzl", rules_ai_py_toolchain = "py_toolchain")
 
-py_repositories()
+rules_ai_py_toolchain(python_version = "3.9", python_repo_name = "python39")
 
-# Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
-
-#load("@python39//:defs.bzl", "interpreter")
-
-# Because we drop out the pip_parse(), we need to explicitly call one of the magic hidden helper-functions:
-load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
-
-pip_install_dependencies()
+# Load a pre-curated set of default per-OS requirements, naming the repo "pypi", then (a standard
+# step of "rules_python" use) install the dependencies defined in this vendored requirements spec
 
 load("@rules_ai//:requirements.bzl", "vendored_requirements")
 

--- a/examples/huggingface_transformer_fillmask/WORKSPACE
+++ b/examples/huggingface_transformer_fillmask/WORKSPACE
@@ -2,9 +2,9 @@
 
 workspace(name = "huggingface_transformer_fillmask")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # if copy-pasting, use this instead:
+#
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # http_archive(
 #     name = "rules_ai",
 #     sha256 = "...",
@@ -20,20 +20,12 @@ load("@rules_ai//:deps.bzl", rules_ai_dependencies = "dependencies")
 
 rules_ai_dependencies()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_ai//:python_defs.bzl", rules_ai_py_toolchain = "py_toolchain")
 
-py_repositories()
+rules_ai_py_toolchain(python_version = "3.9", python_repo_name = "python39")
 
-# Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
-
-# Because we drop out the pip_parse(), we need to explicitly call one of the magic hidden helper-functions:
-load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
-
-pip_install_dependencies()
+# Load a pre-curated set of default per-OS requirements, naming the repo "pypi", then (a standard
+# step of "rules_python" use) install the dependencies defined in this vendored requirements spec
 
 load("@rules_ai//:requirements.bzl", "vendored_requirements")
 

--- a/examples/huggingface_transformer_named_entity_recognition/WORKSPACE
+++ b/examples/huggingface_transformer_named_entity_recognition/WORKSPACE
@@ -2,9 +2,9 @@
 
 workspace(name = "huggingface_transformer_named_entity_recognition")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # if copy-pasting, use this instead:
+#
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # http_archive(
 #     name = "rules_ai",
 #     sha256 = "...",
@@ -20,22 +20,12 @@ load("@rules_ai//:deps.bzl", rules_ai_dependencies = "dependencies")
 
 rules_ai_dependencies()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_ai//:python_defs.bzl", rules_ai_py_toolchain = "py_toolchain")
 
-py_repositories()
+rules_ai_py_toolchain(python_version = "3.9", python_repo_name = "python39")
 
-# Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
-
-#load("@python39//:defs.bzl", "interpreter")
-
-# Because we drop out the pip_parse(), we need to explicitly call one of the magic hidden helper-functions:
-load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
-
-pip_install_dependencies()
+# Load a pre-curated set of default per-OS requirements, naming the repo "pypi", then (a standard
+# step of "rules_python" use) install the dependencies defined in this vendored requirements spec
 
 load("@rules_ai//:requirements.bzl", "vendored_requirements")
 

--- a/examples/huggingface_transformer_question_answering/WORKSPACE
+++ b/examples/huggingface_transformer_question_answering/WORKSPACE
@@ -2,9 +2,9 @@
 
 workspace(name = "huggingface_transformer_question_answering")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 # if copy-pasting, use this instead:
+#
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # http_archive(
 #     name = "rules_ai",
 #     sha256 = "...",
@@ -20,20 +20,12 @@ load("@rules_ai//:deps.bzl", rules_ai_dependencies = "dependencies")
 
 rules_ai_dependencies()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_ai//:python_defs.bzl", rules_ai_py_toolchain = "py_toolchain")
 
-py_repositories()
+rules_ai_py_toolchain(python_version = "3.9", python_repo_name = "python39")
 
-# Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)
-
-# Because we drop out the pip_parse(), we need to explicitly call one of the magic hidden helper-functions:
-load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
-
-pip_install_dependencies()
+# Load a pre-curated set of default per-OS requirements, naming the repo "pypi", then (a standard
+# step of "rules_python" use) install the dependencies defined in this vendored requirements spec
 
 load("@rules_ai//:requirements.bzl", "vendored_requirements")
 

--- a/python_defs.bzl
+++ b/python_defs.bzl
@@ -1,0 +1,19 @@
+# After a call to "deps()" defines external repositories that might not be defined/overridden by
+# the user, this file collects some python setup functions.
+#
+# The intent is for a simplification of what the user needs to maintain.
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
+
+def py_toolchain(python_version = "3.9", python_repo_name = "python39"):
+    py_repositories()
+
+    # Set up a python-3.9 toolchain, then use that interpreter for the @pypi dependency based on resolving the requirements_lock file
+    python_register_toolchains(name = python_repo_name, python_version = python_version)
+
+    # Because we drop out the pip_parse(), we need to explicitly call one of the magic hidden helper-functions:
+    pip_install_dependencies()
+
+


### PR DESCRIPTION
This PR rolls a few steps into a `python_defs.bzl` file that feels a bit sub-optimal but reduces the amount of cut-n-paste necessary to use rules_ai.  Less code to write is less to maintain.