### PR TITLE
fix: resolve main funcs in old style of pipeline instantiation

### DIFF
--- a/examples/huggingface_transformer_distilgpt2/main.py
+++ b/examples/huggingface_transformer_distilgpt2/main.py
@@ -8,7 +8,9 @@ def generate() -> pipelines.text_generation.TextGenerationPipeline:
 
 
 def main():
-    gen = generate(
+    generator = generate()
+
+    gen = generator(
         "In this course, we will teach you how to",
         max_length=30,
         num_return_sequences=2,

--- a/examples/huggingface_transformer_fillmask/main.py
+++ b/examples/huggingface_transformer_fillmask/main.py
@@ -16,7 +16,10 @@ def fillmask() -> pipelines.fill_mask.FillMaskPipeline:
 
 
 def main():
-    # Exercise/acivate the pipeline
+    # Instantiate the pipeline
+    maskfiller = fillmask()
+
+    # Exercise it
     fill = maskfiller("I am hungry for <mask> icecream", top_k=3)
     print(f"Result: {fill}")
 

--- a/examples/huggingface_transformer_named_entity_recognition/main.py
+++ b/examples/huggingface_transformer_named_entity_recognition/main.py
@@ -11,7 +11,11 @@ def recognize() -> pipelines.token_classification.TokenClassificationPipeline:
 
 
 def main():
-    rec = recognize(
+    # Instantiate the pipeline
+    recognizer = recognize()
+
+    # Exercise the pipeline
+    rec = recognizer(
         "Hi I'm Allan Clark from Seattle, and I used the Bazel tool at Apple, Snap, and BCAI"
     )
     print(f"Result: {rec}")

--- a/examples/huggingface_transformer_question_answering/main.py
+++ b/examples/huggingface_transformer_question_answering/main.py
@@ -12,8 +12,11 @@ def qa() -> pipelines.question_answering.QuestionAnsweringPipeline:
 
 
 def main():
-    # Exercise/acivate the pipeline
-    answer = qa(
+    # Instantiate the pipeline
+    answering = qa()
+
+    # Exercise the pipeline
+    answer = answering(
         question="What did I eat?",
         context="We went down to the dock and met a few friends.  I gobbled a cookie and drank some very sweet tea as we walked the length of the docks",
     )


### PR DESCRIPTION
In focusing on unittests, some of the pipeline instantiation changed, but the main functions didn't get fixed -- and then didn't get unittested because python doesn't interpret at build time, it just parses.  Who knows if it runs without 100.0% code coverage ?

Periodically running the main func of the usage-testing examples confirms whether they still run.  This PR fixes a few.