### PR TITLE
ci: Add import of gpg key to CI/CD

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -28,6 +28,9 @@ jobs:
         # https://github.com/bazelbuild/bazel/issues/11062
       - run: mkdir -p "${TEST_TMPDIR}"
       - run: env | sort
+      - name: Import private GPG key from variable PRIVATE_GPG_KEY
+        run: echo "${{ secrets.PRIVATE_GPG_KEY }}" | gpg2 --import
+      - run: gpg2 --list-secret-keys
       - name: Mount bazel cache  # Optional
         uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ if __name__ == "__main__":
 
 ### Running your first program
 
-`bazel build //...` of course builds everything, 
+`bazel build //...` of course builds everything,
 `bazel test //...` of course tests everything (all one unittests)
 `bazel run :main` will run the resulting `bazel-bin/main`:
 

--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -81,7 +81,7 @@ iBazel - Version v0.23.7
 
 2. Check that `bazel` is responding (as bazelisk) and shows both versions:
 ```
-$ bazel version 2>&1 | head -2 
+$ bazel version 2>&1 | head -2
 Bazelisk version: v1.18.0
 Build label: 6.3.2
 ```


### PR DESCRIPTION
In order to test SOPS, I need to have a functioning GPG key, which means a functioning process to unpack a repo secret as a key and import it for use by `sops`.