### PR TITLE
chore: enable python manager to see lib/python/requirements.txt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,8 @@
   "packageRules": [
     {
       "automerge": true,
-      "enabled": false,
-      "matchManagers": [ "bazel" ],
+      "enabled": true,
+      "matchManagers": [ "bazel", "python" ],
       "matchUpdateTypes": [ "patch", "minor" ]
     }
   ],


### PR DESCRIPTION
See if we can get RenovateBot coverage on the python requirements file in //lib/python:requirements.txt